### PR TITLE
Bump to 1.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,50 +2,50 @@
 {% set sha256 = "c8459c15b75a65f2f468fd0a372cf3bc2262262fd6277054de7c2029bff64678" %}
 
 package:
-    name: prompt_toolkit
-    version: {{ version }}
+  name: prompt_toolkit
+  version: {{ version }}
 
 source:
-    fn: python-prompt-toolkit-{{ version }}.tar.gz
-    url: https://github.com/jonathanslenders/python-prompt-toolkit/archive/{{ version }}.tar.gz
-    sha256: {{ sha256 }}
+  fn: python-prompt-toolkit-{{ version }}.tar.gz
+  url: https://github.com/jonathanslenders/python-prompt-toolkit/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-    number: 0
-    script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
-        - pygments
-        - six >=1.9.0
-        - wcwidth
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pygments
+    - six >=1.9.0
+    - wcwidth
 
 test:
-    imports:
-        - prompt_toolkit
-        - prompt_toolkit.clipboard
-        - prompt_toolkit.contrib
-        - prompt_toolkit.contrib.completers
-        - prompt_toolkit.contrib.regular_languages
-        - prompt_toolkit.contrib.telnet  # [not win]
-        - prompt_toolkit.contrib.validators
-        - prompt_toolkit.eventloop
-        - prompt_toolkit.filters
-        - prompt_toolkit.key_binding
-        - prompt_toolkit.key_binding.bindings
-        - prompt_toolkit.layout
-        - prompt_toolkit.terminal
+  imports:
+    - prompt_toolkit
+    - prompt_toolkit.clipboard
+    - prompt_toolkit.contrib
+    - prompt_toolkit.contrib.completers
+    - prompt_toolkit.contrib.regular_languages
+    - prompt_toolkit.contrib.telnet  # [not win]
+    - prompt_toolkit.contrib.validators
+    - prompt_toolkit.eventloop
+    - prompt_toolkit.filters
+    - prompt_toolkit.key_binding
+    - prompt_toolkit.key_binding.bindings
+    - prompt_toolkit.layout
+    - prompt_toolkit.terminal
 
 about:
-    home: https://github.com/jonathanslenders/python-prompt-toolkit
-    license: BSD 3-clause
-    summary: Library for building powerful interactive command lines in Python
+  home: https://github.com/jonathanslenders/python-prompt-toolkit
+  license: BSD 3-clause
+  summary: Library for building powerful interactive command lines in Python
 
 extra:
-    recipe-maintainers:
-        - ocefpaf
-        - scopatz
+  recipe-maintainers:
+    - ocefpaf
+    - scopatz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "1.0.5" %}
-{% set sha256 = "c8459c15b75a65f2f468fd0a372cf3bc2262262fd6277054de7c2029bff64678" %}
+{% set name = "prompt_toolkit" %}
+{% set version = "1.0.6" %}
+{% set sha256 = "5f50fb700bcd1c820b4d135c3fa84d7e94ffd6dc7b2766a15215bdc810aa4f07" %}
 
 package:
-  name: prompt_toolkit
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: python-prompt-toolkit-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/jonathanslenders/python-prompt-toolkit/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,5 +47,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - jakirkham
     - ocefpaf
     - scopatz


### PR DESCRIPTION
**Changes in this PR:**

* Bumps to version 1.0.6.
* Switches to 2-space indents.
* Add myself as a maintainer.
* ~~Get the source from PyPI.~~

**Changes in this release:**

```
1.0.6: 2016-08-15
-----------------

Fixes:
- Go to the start of the line in Vi nagivation mode, when 'j' or 'k' have been
  pressed to navigate to a new history entry.
- Don't crash when pasting text that contains \r\n characters. (This could
  happen in iTerm2.)
- Python 2.6 compatibility fix.
- Allow pressing <esc> before each -ve argument.
- Better support for conversion from #ffffff values to ANSI colors in
  Vt100_Output.
    * Prefer colors with some saturation, instead of gray colors, if the given
      color was not gray.
    * Prefer a different foreground and background color if they were
      originally not the same. (This avoids concealing text.)

New features:
- Improved ANSI color support.
    * If the $PROMPT_TOOLKIT_ANSI_COLORS_ONLY environment variable has been
      set, use the 16 ANSI colors only.
    * Take an `ansi_colors_only` parameter in `Vt100_Output` and
`shortcuts.create_output`.
```