### PR TITLE
Seems like prompt-toolkit no longer depends on six

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ outputs:
       run:
         - python >=3.6
         - pygments
-        - six >=1.9.0
         - wcwidth
       run_constrained:
         - prompt_toolkit {{ version }}


### PR DESCRIPTION
see: https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/setup.py#L31